### PR TITLE
Add Portainer stack

### DIFF
--- a/docker/portainer.yaml
+++ b/docker/portainer.yaml
@@ -1,8 +1,8 @@
 # DOMAIN=example.com docker stack deploy -c portainer.yaml portainer
 version: "3.9"
 
-# Portainer communicates with agents using portainer network.
-# Portainer dashboard is exposed via public network.
+# Portainer communicates with agents using "portainer" network.
+# Portainer dashboard is exposed via "public" network.
 networks:
   default:
     name: portainer
@@ -34,13 +34,15 @@ services:
       - default
       - public
     deploy:
+      # You could run Portainer in HA mode but IMO one instance is enough.
+      # mode: global
       mode: replicated
       replicas: 1
       placement:
         # Since we use CEPH for docker volumes can place to any manager node.
         constraints: [node.role == manager]
         # You could also force placement to specific node with labels.
-        #constraints: [node.labels.com.example.service == portainer]
+        # constraints: [node.labels.com.example.service == portainer]
       labels:
         # Make Traefik dashboard available via Traefik proxy.
         - traefik.enable=true

--- a/docker/portainer.yaml
+++ b/docker/portainer.yaml
@@ -53,8 +53,7 @@ services:
         - traefik.http.routers.portainer-https.tls=true
         - traefik.http.routers.portainer-https.tls.certresolver=le
 
-        # Redirect http traffic to https. The middleware is already defined
-        # in traefik.yaml.
+        # Redirect http traffic to https. The middleware is defined in traefik.yaml.
         - traefik.http.routers.portainer-http.rule=Host(`portainer.${DOMAIN:-localhost}`)
         - traefik.http.routers.portainer-http.entrypoints=http
         - traefik.http.routers.portainer-http.middlewares=https-redirect

--- a/docker/portainer.yaml
+++ b/docker/portainer.yaml
@@ -1,0 +1,60 @@
+# DOMAIN=example.com docker stack deploy -c portainer.yaml portainer
+version: "3.9"
+
+# Portainer communicates with agents using portainer network.
+# Portainer dashboard is exposed via public network.
+networks:
+  default:
+    name: portainer
+  public:
+    external: true
+
+volumes:
+  data:
+
+services:
+  agent:
+    image: portainer/agent:2.17.1-alpine
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes
+    networks:
+      - default
+    deploy:
+      mode: global
+      placement:
+        constraints: [node.platform.os == linux]
+
+  portainer:
+    image: portainer/portainer-ce:2.17.1-alpine
+    command: -H tcp://tasks.agent:9001 --tlsskipverify
+    volumes:
+      - data:/data
+    networks:
+      - default
+      - public
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        # Since we use CEPH for docker volumes can place to any manager node.
+        constraints: [node.role == manager]
+        # You could also force placement to specific node with labels.
+        #constraints: [node.labels.com.example.service == portainer]
+      labels:
+        # Make Traefik dashboard available via Traefik proxy.
+        - traefik.enable=true
+        - traefik.docker.network=public
+        - traefik.http.services.portainer.loadbalancer.server.port=9000
+
+        # Serve pages via https. Encrypt with certificate from Let's Encrypt.
+        - traefik.http.routers.portainer-https.rule=Host(`portainer.${DOMAIN:-localhost}`)
+        - traefik.http.routers.portainer-https.entrypoints=https
+        - traefik.http.routers.portainer-https.tls=true
+        - traefik.http.routers.portainer-https.tls.certresolver=le
+
+        # Redirect http traffic to https. The middleware is already defined
+        # in traefik.yaml.
+        - traefik.http.routers.portainer-http.rule=Host(`portainer.${DOMAIN:-localhost}`)
+        - traefik.http.routers.portainer-http.entrypoints=http
+        - traefik.http.routers.portainer-http.middlewares=https-redirect

--- a/docker/portainer.yaml
+++ b/docker/portainer.yaml
@@ -1,4 +1,5 @@
-# DOMAIN=example.com docker stack deploy -c portainer.yaml portainer
+# export INITIAL_PASSWORD=$(htpasswd -nB admin | cut -d ":" -f 2)
+# DOMAIN=example.com  docker stack deploy -c portainer.yaml portainer
 version: "3.9"
 
 # Portainer communicates with agents using "portainer" network.
@@ -27,7 +28,8 @@ services:
 
   portainer:
     image: portainer/portainer-ce:2.17.1-alpine
-    command: -H tcp://tasks.agent:9001 --tlsskipverify
+    # --admin-password is only used when first creating the admin user.
+    command: -H tcp://tasks.agent:9001 --tlsskipverify --admin-password ${INITIAL_PASSWORD:-admin}
     volumes:
       - data:/data
     networks:


### PR DESCRIPTION
Domain defaults to localhost which can be used when testing. Otherwise set to your own domain. Portainer will ask to update password when you first log in.

```
$ docker stack deploy -c portainer.yaml portainer
$ DOMAIN=example.com docker stack deploy -c portainer.yaml portainer
```

https://portainer.localhost
https://portainer.example.com