### PR TITLE
Add monitoring stack

### DIFF
--- a/ansible/node_exporter.yaml
+++ b/ansible/node_exporter.yaml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - prometheus.prometheus.node_exporter

--- a/docker/etc/grafana/provisioning/datasources/prometheus.yaml
+++ b/docker/etc/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    version: 1
+    editable: true

--- a/docker/etc/prometheus/prometheus.yaml
+++ b/docker/etc/prometheus/prometheus.yaml
@@ -1,0 +1,20 @@
+# This is served as a docker config. After editing run:
+#
+# $ docker stack rm monitoring
+# $ DOMAIN=example.com docker stack deploy -c monitoring.yaml monitoring
+
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: prometheus
+    scrape_interval: 1m
+    static_configs:
+      - targets: ["prometheus:9090"]
+  - job_name: node
+    static_configs:
+      - targets: ["manager-01:9100", "manager-02:9100", "manager-03:9100"]
+  - job_name: grafana
+    static_configs:
+      - targets: ["grafana:3000"]

--- a/docker/monitoring.yaml
+++ b/docker/monitoring.yaml
@@ -1,0 +1,84 @@
+# DOMAIN=example.com docker stack deploy -c monitoring.yaml monitoring
+version: "3.9"
+
+# Prometheus scrapes nodes using "monitoring" network.
+# Prometheus and Grafana dashboards are exposed via "public" network.
+networks:
+  default:
+    name: monitoring
+  public:
+    external: true
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
+configs:
+  prometheus_config:
+    file: ./etc/prometheus/prometheus.yaml
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.42.0
+    volumes:
+      - prometheus_data:/prometheus
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus.yaml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yaml
+      - --storage.tsdb.path=/prometheus
+    networks:
+      - public
+      - default
+    extra_hosts:
+      # Add physical node VLAN ip addresses to /etc/hosts.
+      - "manager-01:10.0.0.1"
+      - "manager-02:10.0.0.2"
+      - "manager-03:10.0.0.3"
+      # TODO: this should be automatic
+      # - "manager-04:10.0.0.4"
+      # - "manager-05:10.0.0.5"
+      # - "worker-01:10.0.0.6"
+      # - "worker-02:10.0.0.7"
+      # - "worker-03:10.0.0.8"
+      # - "worker-04:10.0.0.9"
+      # - "worker-05:10.0.0.10"
+    deploy:
+      # Since we use CEPH for volumes Prometheus can placed to any node.
+      mode: replicated
+      replicas: 1
+      labels:
+        # Make Prometheus console available via Traefik proxy.
+        - traefik.enable=true
+        - traefik.docker.network=public
+        - traefik.http.services.prometheus.loadbalancer.server.port=9090
+
+        # Serve pages via https. Encrypt with certificate from Let's Encrypt.
+        - traefik.http.routers.prometheus-https.rule=Host(`prometheus.${DOMAIN:-localhost}`)
+        - traefik.http.routers.prometheus-https.entrypoints=https
+        - traefik.http.routers.prometheus-https.tls=true
+        - traefik.http.routers.prometheus-https.tls.certresolver=le
+
+  grafana:
+    image: grafana/grafana:9.4.3
+    volumes:
+      - grafana_data:/var/lib/grafana
+    networks:
+      - default
+      - public
+    deploy:
+      # Since we use CEPH for volumes Grafana can placed to any node.
+      mode: replicated
+      replicas: 1
+      labels:
+        # Make Grafana available via Traefik proxy.
+        - traefik.enable=true
+        - traefik.docker.network=public
+        - traefik.http.services.grafana.loadbalancer.server.port=3000
+
+        # Serve pages via https. Encrypt with certificate from Let's Encrypt.
+        - traefik.http.routers.grafana-https.rule=Host(`grafana.${DOMAIN:-localhost}`)
+        - traefik.http.routers.grafana-https.entrypoints=https
+        - traefik.http.routers.grafana-https.tls=true
+        - traefik.http.routers.grafana-https.tls.certresolver=le

--- a/docker/monitoring.yaml
+++ b/docker/monitoring.yaml
@@ -16,6 +16,8 @@ volumes:
 configs:
   prometheus_config:
     file: ./etc/prometheus/prometheus.yaml
+  grafana_datasources:
+    file: ./etc/grafana/provisioning/datasources/prometheus.yaml
 
 services:
   prometheus:
@@ -61,9 +63,12 @@ services:
         - traefik.http.routers.prometheus-https.tls.certresolver=le
 
   grafana:
-    image: grafana/grafana:9.4.3
+    image: grafana/grafana:9.4.7
     volumes:
       - grafana_data:/var/lib/grafana
+    configs:
+      - source: grafana_datasources
+        target: /etc/grafana/provisioning/datasources/prometheus.yaml
     networks:
       - default
       - public


### PR DESCRIPTION
Domain defaults to localhost which can be used when testing. Otherwise
set to your own domain. You most likely also want to install node 
exporter to all nodes.

```
$ DOMAIN=example.com docker stack deploy -c monitoring.yaml monitoring
$ ansible-playbook -v node_exporter.yaml
```

https://prometheus.example.com/
https://grafana.example.com/

Dashboards are not automatically installed. You should install at least
Node Exporter Full dashboard.

https://grafana.com/grafana/dashboards/1860-node-exporter-full/


